### PR TITLE
Implement Docker CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,23 @@
+name: CD
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/automacao-infra-aws:latest
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . .
+RUN pip install --no-cache-dir boto3
+CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -27,3 +27,13 @@ python cleanup_resources.py --region us-east-1 --delete
 ```
 
 > **Warning**: Deleting resources is irreversible. Ensure you really want to remove all listed resources before using the `--delete` flag.
+
+## Docker
+
+A Docker image is built and published automatically to Docker Hub from the `main` branch. You can run the cleanup scripts using:
+
+```bash
+docker run --rm -v $(pwd)/config:/app/config DOCKERHUB_USERNAME/automacao-infra-aws:latest
+```
+
+Replace `DOCKERHUB_USERNAME` with the Docker Hub user configured in the workflow secrets.


### PR DESCRIPTION
## Summary
- add Dockerfile to package cleanup scripts
- add CD workflow that publishes the container image to Docker Hub
- document Docker usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685774729c808324b247ef441794fdf4